### PR TITLE
Tweak requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,20 +6,9 @@ pillow
 tifffile
 pyyaml
 pandas
-attrs
-sip
-#pyqt4
+scikit-beam
+databroker
 
-
-
-git+https://github.com/scikit-beam/scikit-beam.gitciki-beam#egg=scikit-beam
-git+https://github.com/NSLS-II/databroker#egg=databroker
-git+https://github.com/NSLS-II/metadatastore#egg=metadatastore
-git+https://github.com/NSLS-II/filestore#egg=filestore
 git+https://github.com/yugangzhang/eiger-io.git#eiger-io
 git+https://github.com/NSLS-II-CHX/chxtools.git#egg=chxtools
 git+https://github.com/Nikea/xray-vision.git#Xray-vision
-
-
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy
+cython
 matplotlib
 scipy
 lmfit
@@ -6,9 +7,9 @@ pillow
 tifffile
 pyyaml
 pandas
-scikit-beam
 databroker
 
+git+https://github.com/scikit-beam/scikit-beam.git#egg=scikit-beam
 git+https://github.com/yugangzhang/eiger-io.git#eiger-io
 git+https://github.com/NSLS-II-CHX/chxtools.git#egg=chxtools
 git+https://github.com/Nikea/xray-vision.git#Xray-vision


### PR DESCRIPTION
 - sckitbeam and databroker are now in pypi, no need for git installs
 - metadatastore and filestore are deprecated and should not be installed
 - should not be installing sip explicitly
 - should not be installing attrs directly (databroker dependency)